### PR TITLE
Fix frame flickering in the imagery plugin due to resizing with uninitialized image parameters

### DIFF
--- a/src/plugins/imagery/components/ImageryView.vue
+++ b/src/plugins/imagery/components/ImageryView.vue
@@ -802,8 +802,6 @@ export default {
             return [ARROW_RIGHT, ARROW_LEFT].includes(keyCode);
         },
         getImageNaturalDimensions() {
-            this.focusedImageNaturalAspectRatio = undefined;
-
             const img = this.$refs.focusedImage;
             if (!img) {
                 return;


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #1 .

### Describe your changes:

`VueComponent.focusedImageNaturalAspectRatio` is initialized to undefined in https://github.com/ami-iit/openmct/blob/d30c4fcb5371aeffbb9b4464a43d3b701da3eae1/src/plugins/imagery/components/ImageryView.vue#L276.

It was then reset in `getImageNaturalDimensions()` to `undefined` every-time a new image was loaded,
https://github.com/ami-iit/openmct/blob/d30c4fcb5371aeffbb9b4464a43d3b701da3eae1/src/plugins/imagery/components/ImageryView.vue#L952-L954

...before the call to `computed.sizedImageDimensions()`. If instead, we remove this reset, the previous image aspect ratio is used.

_Originally posted by @nunoguedelha in https://github.com/ami-iit/yarp-openmct/issues/103#issuecomment-1115552080_


### All Submissions:

* ~Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?~
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] ~Unit tests included and/or updated with changes?~
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?

<!---
### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
-->